### PR TITLE
Add MSI tool releases to WinGet feed

### DIFF
--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: write
       actions: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -63,19 +64,30 @@ jobs:
             "${{ steps.payload.outputs.product_code }}"
 
       - name: Commit changes
+        id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          branch="automation/update-${{ steps.payload.outputs.package_key }}-${{ steps.payload.outputs.version }}-${{ github.run_id }}"
+          git switch -c "$branch"
           git add index.json manifests packageManifests
           if git diff --cached --quiet; then
             echo "No changes to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git commit -m "Update ${{ steps.payload.outputs.package_key }} to ${{ steps.payload.outputs.version }}"
-          git push
+          git push --set-upstream origin "$branch"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
 
-      - name: Dispatch feed deploy
-        if: success()
+      - name: Open package update pull request
+        if: steps.commit.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run deploy-feed.yml --ref main
+        run: |
+          gh pr create \
+            --base main \
+            --head "${{ steps.commit.outputs.branch }}" \
+            --title "Update ${{ steps.payload.outputs.package_key }} to ${{ steps.payload.outputs.version }}" \
+            --body "Generated WinGet manifests for ${{ steps.payload.outputs.package_key }} ${{ steps.payload.outputs.version }}."

--- a/index.json
+++ b/index.json
@@ -32,6 +32,54 @@
           }
         }
       ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.MailTriage",
+      "PackageName": "Mail Triage",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.1.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "Mail Triage",
+            "ShortDescription": "Inbox triage with compact JSON output for notification and follow-up workflows"
+          }
+        }
+      ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.CalendarGlance",
+      "PackageName": "Calendar Glance",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.1.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "Calendar Glance",
+            "ShortDescription": "Read-only Microsoft 365 agenda snapshots for short-range planning and meeting context"
+          }
+        }
+      ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.FileFinder",
+      "PackageName": "File Finder",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.1.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "File Finder",
+            "ShortDescription": "Microsoft 365 file discovery and focused OneDrive actions through delegated Graph"
+          }
+        }
+      ]
     }
   ]
 }

--- a/manifests/m/MidtownTechnologyGroup/CalendarGlance/0.1.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/CalendarGlance/0.1.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.CalendarGlance
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{8420AC56-8F09-421D-92ED-C782D032572E}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/calendar-glance/releases/download/v0.1.0/calendar-glance.msi
+    InstallerSha256: d9a65768aaf299f2145b6646ebbb32340701dbfba9cb259147901abab3cfcf1f
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/CalendarGlance/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/CalendarGlance/locale.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.CalendarGlance
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/calendar-glance/issues
+Author: Thomas Bray
+PackageName: Calendar Glance
+PackageUrl: https://github.com/Midtown-Technology-Group/calendar-glance
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Midtown-Technology-Group/calendar-glance/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Read-only Microsoft 365 agenda snapshots for short-range planning and meeting context
+Description: |
+  Calendar Glance provides read-only Microsoft 365 agenda snapshots for short-range planning and meeting context.
+Moniker: calendar-glance
+Tags:
+  - calendar
+  - microsoft-graph
+  - microsoft-365
+  - planning
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for Calendar Glance.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/calendar-glance/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/CalendarGlance/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/CalendarGlance/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.CalendarGlance
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/FileFinder/0.1.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/FileFinder/0.1.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.FileFinder
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{5953A087-F8C0-48C1-9639-13429237AC2E}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/file-finder/releases/download/v0.1.0/file-finder.msi
+    InstallerSha256: 12adf65666c94ead160d358ea17ee5aea77b141790c1c0e4745262ce2ff537ff
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/FileFinder/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/FileFinder/locale.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.FileFinder
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/file-finder/issues
+Author: Thomas Bray
+PackageName: File Finder
+PackageUrl: https://github.com/Midtown-Technology-Group/file-finder
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Midtown-Technology-Group/file-finder/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Microsoft 365 file discovery and focused OneDrive actions through delegated Graph
+Description: |
+  File Finder provides Microsoft 365 file discovery and focused OneDrive actions through delegated Microsoft Graph.
+Moniker: file-finder
+Tags:
+  - files
+  - onedrive
+  - microsoft-graph
+  - microsoft-365
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for File Finder.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/file-finder/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/FileFinder/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/FileFinder/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.FileFinder
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/MailTriage/0.1.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/MailTriage/0.1.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.MailTriage
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{9145C120-2C27-467C-8CB8-0902A0911DC9}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/mail-triage/releases/download/v0.1.0/mail-triage.msi
+    InstallerSha256: 3ed5aa3353b481da28069202c4a9bf5fd2cf115155680d7a0f49d025a4889bf0
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/MailTriage/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/MailTriage/locale.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.MailTriage
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/mail-triage/issues
+Author: Thomas Bray
+PackageName: Mail Triage
+PackageUrl: https://github.com/Midtown-Technology-Group/mail-triage
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/Midtown-Technology-Group/mail-triage/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Inbox triage with compact JSON output for notification and follow-up workflows
+Description: |
+  Mail Triage provides Microsoft 365 inbox triage and delegated mail actions for Midtown operator workflows.
+Moniker: mail-triage
+Tags:
+  - mail
+  - microsoft-graph
+  - microsoft-365
+  - productivity
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for Mail Triage.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/mail-triage/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/MailTriage/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/MailTriage/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.MailTriage
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/packageManifests/m/MidtownTechnologyGroup/CalendarGlance/0.1.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/CalendarGlance/0.1.0.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.CalendarGlance",
+    "versions": [
+      {
+        "packageVersion": "0.1.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/calendar-glance/issues",
+          "author": "Thomas Bray",
+          "packageName": "Calendar Glance",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/calendar-glance",
+          "license": "GPL-3.0-or-later",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/calendar-glance/blob/main/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Read-only Microsoft 365 agenda snapshots for short-range planning and meeting context",
+          "description": "Calendar Glance provides read-only Microsoft 365 agenda snapshots for short-range planning and meeting context.",
+          "moniker": "calendar-glance",
+          "tags": [
+            "calendar",
+            "microsoft-graph",
+            "microsoft-365",
+            "planning",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for Calendar Glance.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/calendar-glance/releases/tag/v0.1.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/calendar-glance/releases/download/v0.1.0/calendar-glance.msi",
+            "installerSha256": "d9a65768aaf299f2145b6646ebbb32340701dbfba9cb259147901abab3cfcf1f",
+            "productCode": "{8420AC56-8F09-421D-92ED-C782D032572E}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packageManifests/m/MidtownTechnologyGroup/FileFinder/0.1.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/FileFinder/0.1.0.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.FileFinder",
+    "versions": [
+      {
+        "packageVersion": "0.1.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/file-finder/issues",
+          "author": "Thomas Bray",
+          "packageName": "File Finder",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/file-finder",
+          "license": "GPL-3.0-or-later",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/file-finder/blob/main/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Microsoft 365 file discovery and focused OneDrive actions through delegated Graph",
+          "description": "File Finder provides Microsoft 365 file discovery and focused OneDrive actions through delegated Microsoft Graph.",
+          "moniker": "file-finder",
+          "tags": [
+            "files",
+            "onedrive",
+            "microsoft-graph",
+            "microsoft-365",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for File Finder.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/file-finder/releases/tag/v0.1.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/file-finder/releases/download/v0.1.0/file-finder.msi",
+            "installerSha256": "12adf65666c94ead160d358ea17ee5aea77b141790c1c0e4745262ce2ff537ff",
+            "productCode": "{5953A087-F8C0-48C1-9639-13429237AC2E}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packageManifests/m/MidtownTechnologyGroup/MailTriage/0.1.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/MailTriage/0.1.0.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.MailTriage",
+    "versions": [
+      {
+        "packageVersion": "0.1.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/mail-triage/issues",
+          "author": "Thomas Bray",
+          "packageName": "Mail Triage",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/mail-triage",
+          "license": "GPL-3.0-or-later",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/mail-triage/blob/main/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Inbox triage with compact JSON output for notification and follow-up workflows",
+          "description": "Mail Triage provides Microsoft 365 inbox triage and delegated mail actions for Midtown operator workflows.",
+          "moniker": "mail-triage",
+          "tags": [
+            "mail",
+            "microsoft-graph",
+            "microsoft-365",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for Mail Triage.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/mail-triage/releases/tag/v0.1.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/mail-triage/releases/download/v0.1.0/mail-triage.msi",
+            "installerSha256": "3ed5aa3353b481da28069202c4a9bf5fd2cf115155680d7a0f49d025a4889bf0",
+            "productCode": "{9145C120-2C27-467C-8CB8-0902A0911DC9}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add WinGet feed entries for mail-triage, calendar-glance, and file-finder v0.1.0 MSI releases
- capture the published MSI URLs, SHA256 hashes, and product codes from the release workflow outputs
- change package update automation to open PRs instead of pushing protected main directly

## Verification
- python -m json.tool index.json
- python -m json.tool packageManifests/m/MidtownTechnologyGroup/MailTriage/0.1.0.json
- python -m json.tool packageManifests/m/MidtownTechnologyGroup/CalendarGlance/0.1.0.json
- python -m json.tool packageManifests/m/MidtownTechnologyGroup/FileFinder/0.1.0.json
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->