### PR TITLE
Add package metadata for Python tools

### DIFF
--- a/packages/context-sync.json
+++ b/packages/context-sync.json
@@ -1,0 +1,31 @@
+{
+  "packageIdentifier": "MidtownTechnologyGroup.ContextSync",
+  "packageName": "Context Sync",
+  "publisher": "Midtown Technology Group LLC",
+  "publisherUrl": "https://midtowntg.com",
+  "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/context-sync/issues",
+  "author": "Thomas Bray",
+  "packageUrl": "https://github.com/Midtown-Technology-Group/context-sync",
+  "license": "MIT",
+  "licenseUrl": "https://github.com/Midtown-Technology-Group/context-sync/blob/main/LICENSE",
+  "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+  "shortDescription": "Sync Microsoft 365 work context to LogSeq knowledge graph",
+  "description": "Sync Microsoft 365 work context to LogSeq knowledge graph",
+  "moniker": "work-context-sync",
+  "tags": [
+    "logseq",
+    "microsoft-365",
+    "cli",
+    "productivity",
+    "midtown"
+  ],
+  "releaseNotes": "Initial MSI release for Context Sync.",
+  "repo": "Midtown-Technology-Group/context-sync",
+  "assetName": "work-context-sync.msi",
+  "architecture": "x64",
+  "installerType": "msi",
+  "scope": "machine",
+  "upgradeBehavior": "install",
+  "silent": "/qn",
+  "silentWithProgress": "/qb"
+}

--- a/packages/detour.json
+++ b/packages/detour.json
@@ -1,0 +1,29 @@
+{
+  "packageIdentifier": "MidtownTechnologyGroup.Detour",
+  "packageName": "Detour",
+  "publisher": "Midtown Technology Group LLC",
+  "publisherUrl": "https://midtowntg.com",
+  "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/detour/issues",
+  "author": "Thomas Bray",
+  "packageUrl": "https://github.com/Midtown-Technology-Group/detour",
+  "license": "AGPL-3.0-only",
+  "licenseUrl": "https://github.com/Midtown-Technology-Group/detour/blob/main/LICENSE",
+  "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+  "shortDescription": "Track the work you did to get back to the work you meant to do.",
+  "description": "Track the work you did to get back to the work you meant to do.",
+  "moniker": "detour",
+  "tags": [
+    "cli",
+    "productivity",
+    "midtown"
+  ],
+  "releaseNotes": "Initial MSI release for Detour.",
+  "repo": "Midtown-Technology-Group/detour",
+  "assetName": "detour.msi",
+  "architecture": "x64",
+  "installerType": "msi",
+  "scope": "machine",
+  "upgradeBehavior": "install",
+  "silent": "/qn",
+  "silentWithProgress": "/qb"
+}

--- a/packages/gtd-dashboard.json
+++ b/packages/gtd-dashboard.json
@@ -1,0 +1,31 @@
+{
+  "packageIdentifier": "MidtownTechnologyGroup.GtdDashboard",
+  "packageName": "GTD Dashboard",
+  "publisher": "Midtown Technology Group LLC",
+  "publisherUrl": "https://midtowntg.com",
+  "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/gtd-dashboard/issues",
+  "author": "Thomas Bray",
+  "packageUrl": "https://github.com/Midtown-Technology-Group/gtd-dashboard",
+  "license": "AGPL-3.0",
+  "licenseUrl": "https://github.com/Midtown-Technology-Group/gtd-dashboard/blob/master/LICENSE",
+  "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+  "shortDescription": "GTD Dashboard CLI for Logseq knowledge graphs",
+  "description": "GTD Dashboard CLI for Logseq knowledge graphs",
+  "moniker": "gtd-dashboard",
+  "tags": [
+    "gtd",
+    "logseq",
+    "cli",
+    "productivity",
+    "midtown"
+  ],
+  "releaseNotes": "Initial MSI release for GTD Dashboard.",
+  "repo": "Midtown-Technology-Group/gtd-dashboard",
+  "assetName": "gtd-dashboard.msi",
+  "architecture": "x64",
+  "installerType": "msi",
+  "scope": "machine",
+  "upgradeBehavior": "install",
+  "silent": "/qn",
+  "silentWithProgress": "/qb"
+}

--- a/packages/halocli.json
+++ b/packages/halocli.json
@@ -1,0 +1,30 @@
+{
+  "packageIdentifier": "MidtownTechnologyGroup.Halocli",
+  "packageName": "Halocli",
+  "publisher": "Midtown Technology Group LLC",
+  "publisherUrl": "https://midtowntg.com",
+  "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/halocli/issues",
+  "author": "Thomas Bray",
+  "packageUrl": "https://github.com/Midtown-Technology-Group/halocli",
+  "license": "GPL-3.0-only",
+  "licenseUrl": "https://github.com/Midtown-Technology-Group/halocli/blob/main/LICENSE",
+  "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+  "shortDescription": "Standalone HaloPSA CLI for safe operator and automation workflows",
+  "description": "Standalone HaloPSA CLI for safe operator and automation workflows",
+  "moniker": "halocli",
+  "tags": [
+    "halo",
+    "cli",
+    "productivity",
+    "midtown"
+  ],
+  "releaseNotes": "Initial MSI release for Halocli.",
+  "repo": "Midtown-Technology-Group/halocli",
+  "assetName": "halocli.msi",
+  "architecture": "x64",
+  "installerType": "msi",
+  "scope": "machine",
+  "upgradeBehavior": "install",
+  "silent": "/qn",
+  "silentWithProgress": "/qb"
+}

--- a/packages/meeting-cost-tracker.json
+++ b/packages/meeting-cost-tracker.json
@@ -1,0 +1,31 @@
+{
+  "packageIdentifier": "MidtownTechnologyGroup.MeetingCostTracker",
+  "packageName": "Meeting Cost Tracker",
+  "publisher": "Midtown Technology Group LLC",
+  "publisherUrl": "https://midtowntg.com",
+  "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/meeting-cost-tracker/issues",
+  "author": "Thomas Bray",
+  "packageUrl": "https://github.com/Midtown-Technology-Group/meeting-cost-tracker",
+  "license": "AGPL-3.0",
+  "licenseUrl": "https://github.com/Midtown-Technology-Group/meeting-cost-tracker/blob/master/LICENSE",
+  "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+  "shortDescription": "Track the real cost of Microsoft Teams meetings by participant time",
+  "description": "Track the real cost of Microsoft Teams meetings by participant time",
+  "moniker": "mct",
+  "tags": [
+    "teams",
+    "time",
+    "cli",
+    "productivity",
+    "midtown"
+  ],
+  "releaseNotes": "Initial MSI release for Meeting Cost Tracker.",
+  "repo": "Midtown-Technology-Group/meeting-cost-tracker",
+  "assetName": "mct.msi",
+  "architecture": "x64",
+  "installerType": "msi",
+  "scope": "machine",
+  "upgradeBehavior": "install",
+  "silent": "/qn",
+  "silentWithProgress": "/qb"
+}

--- a/packages/quick-capture.json
+++ b/packages/quick-capture.json
@@ -1,0 +1,31 @@
+{
+  "packageIdentifier": "MidtownTechnologyGroup.QuickCapture",
+  "packageName": "Quick Capture",
+  "publisher": "Midtown Technology Group LLC",
+  "publisherUrl": "https://midtowntg.com",
+  "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/quick-capture/issues",
+  "author": "Thomas Bray",
+  "packageUrl": "https://github.com/Midtown-Technology-Group/quick-capture",
+  "license": "AGPL-3.0-or-later",
+  "licenseUrl": "https://github.com/Midtown-Technology-Group/quick-capture/blob/main/LICENSE",
+  "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+  "shortDescription": "Fast, frictionless capture for Logseq daily notes",
+  "description": "Fast, frictionless capture for Logseq daily notes",
+  "moniker": "quick-capture",
+  "tags": [
+    "logseq",
+    "notes",
+    "cli",
+    "productivity",
+    "midtown"
+  ],
+  "releaseNotes": "Initial MSI release for Quick Capture.",
+  "repo": "Midtown-Technology-Group/quick-capture",
+  "assetName": "quick-capture.msi",
+  "architecture": "x64",
+  "installerType": "msi",
+  "scope": "machine",
+  "upgradeBehavior": "install",
+  "silent": "/qn",
+  "silentWithProgress": "/qb"
+}

--- a/packages/time-tracker.json
+++ b/packages/time-tracker.json
@@ -1,0 +1,31 @@
+{
+  "packageIdentifier": "MidtownTechnologyGroup.TimeTracker",
+  "packageName": "Time Tracker",
+  "publisher": "Midtown Technology Group LLC",
+  "publisherUrl": "https://midtowntg.com",
+  "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/time-tracker/issues",
+  "author": "Thomas Bray",
+  "packageUrl": "https://github.com/Midtown-Technology-Group/time-tracker",
+  "license": "AGPL-3.0",
+  "licenseUrl": "https://github.com/Midtown-Technology-Group/time-tracker/blob/master/LICENSE",
+  "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+  "shortDescription": "Track time on tasks with zero friction. Integrates with GTD workflows.",
+  "description": "Track time on tasks with zero friction. Integrates with GTD workflows.",
+  "moniker": "time-tracker",
+  "tags": [
+    "gtd",
+    "time",
+    "cli",
+    "productivity",
+    "midtown"
+  ],
+  "releaseNotes": "Initial MSI release for Time Tracker.",
+  "repo": "Midtown-Technology-Group/time-tracker",
+  "assetName": "time-tracker.msi",
+  "architecture": "x64",
+  "installerType": "msi",
+  "scope": "machine",
+  "upgradeBehavior": "install",
+  "silent": "/qn",
+  "silentWithProgress": "/qb"
+}

--- a/packages/weekly-review.json
+++ b/packages/weekly-review.json
@@ -1,0 +1,31 @@
+{
+  "packageIdentifier": "MidtownTechnologyGroup.WeeklyReview",
+  "packageName": "Weekly Review",
+  "publisher": "Midtown Technology Group LLC",
+  "publisherUrl": "https://midtowntg.com",
+  "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/weekly-review/issues",
+  "author": "Thomas Bray",
+  "packageUrl": "https://github.com/Midtown-Technology-Group/weekly-review",
+  "license": "AGPL-3.0",
+  "licenseUrl": "https://github.com/Midtown-Technology-Group/weekly-review/blob/master/LICENSE",
+  "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+  "shortDescription": "Automated GTD weekly review generator for Logseq knowledge graphs",
+  "description": "Automated GTD weekly review generator for Logseq knowledge graphs",
+  "moniker": "weekly-review",
+  "tags": [
+    "gtd",
+    "logseq",
+    "cli",
+    "productivity",
+    "midtown"
+  ],
+  "releaseNotes": "Initial MSI release for Weekly Review.",
+  "repo": "Midtown-Technology-Group/weekly-review",
+  "assetName": "weekly-review.msi",
+  "architecture": "x64",
+  "installerType": "msi",
+  "scope": "machine",
+  "upgradeBehavior": "install",
+  "silent": "/qn",
+  "silentWithProgress": "/qb"
+}


### PR DESCRIPTION
## Summary
- add mtg-winget package metadata for eight remaining Python CLI tools
- prepare package keys for release workflow dispatches from each tool repo

## Verification
- python -m json.tool for each added package metadata file
- git diff --cached --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->