### PR TITLE
Add Python tool releases to WinGet feed

### DIFF
--- a/index.json
+++ b/index.json
@@ -80,6 +80,134 @@
           }
         }
       ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.ContextSync",
+      "PackageName": "Context Sync",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "1.0.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "Context Sync",
+            "ShortDescription": "Sync Microsoft 365 work context to LogSeq knowledge graph"
+          }
+        }
+      ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.Detour",
+      "PackageName": "Detour",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.1.3",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "Detour",
+            "ShortDescription": "Track the work you did to get back to the work you meant to do."
+          }
+        }
+      ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.GtdDashboard",
+      "PackageName": "GTD Dashboard",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.1.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "GTD Dashboard",
+            "ShortDescription": "GTD Dashboard CLI for Logseq knowledge graphs"
+          }
+        }
+      ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.Halocli",
+      "PackageName": "Halocli",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.5.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "Halocli",
+            "ShortDescription": "Standalone HaloPSA CLI for safe operator and automation workflows"
+          }
+        }
+      ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.MeetingCostTracker",
+      "PackageName": "Meeting Cost Tracker",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.1.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "Meeting Cost Tracker",
+            "ShortDescription": "Track the real cost of Microsoft Teams meetings by participant time"
+          }
+        }
+      ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.QuickCapture",
+      "PackageName": "Quick Capture",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.1.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "Quick Capture",
+            "ShortDescription": "Fast, frictionless capture for Logseq daily notes"
+          }
+        }
+      ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.TimeTracker",
+      "PackageName": "Time Tracker",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.1.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "Time Tracker",
+            "ShortDescription": "Track time on tasks with zero friction. Integrates with GTD workflows."
+          }
+        }
+      ]
+    },
+    {
+      "PackageIdentifier": "MidtownTechnologyGroup.WeeklyReview",
+      "PackageName": "Weekly Review",
+      "Publisher": "Midtown Technology Group LLC",
+      "Versions": [
+        {
+          "PackageVersion": "0.1.0",
+          "DefaultLocale": {
+            "PackageLocale": "en-US",
+            "Publisher": "Midtown Technology Group LLC",
+            "PackageName": "Weekly Review",
+            "ShortDescription": "Automated GTD weekly review generator for Logseq knowledge graphs"
+          }
+        }
+      ]
     }
   ]
 }

--- a/manifests/m/MidtownTechnologyGroup/ContextSync/1.0.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/ContextSync/1.0.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.ContextSync
+PackageVersion: 1.0.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{1AFC5B16-0EA6-4616-8D7D-95FB3070E808}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/context-sync/releases/download/v1.0.0/work-context-sync.msi
+    InstallerSha256: fcf457fa69c3cbd09fb0152a268b1c9dd3c05e38f5dc492e39b019df1f3f350d
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/ContextSync/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/ContextSync/locale.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.ContextSync
+PackageVersion: 1.0.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/context-sync/issues
+Author: Thomas Bray
+PackageName: Context Sync
+PackageUrl: https://github.com/Midtown-Technology-Group/context-sync
+License: MIT
+LicenseUrl: https://github.com/Midtown-Technology-Group/context-sync/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Sync Microsoft 365 work context to LogSeq knowledge graph
+Description: |
+  Sync Microsoft 365 work context to LogSeq knowledge graph
+Moniker: work-context-sync
+Tags:
+  - logseq
+  - microsoft-365
+  - cli
+  - productivity
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for Context Sync.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/context-sync/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/ContextSync/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/ContextSync/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.ContextSync
+PackageVersion: 1.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Detour/0.1.3.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Detour/0.1.3.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.Detour
+PackageVersion: 0.1.3
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{303221BB-88BF-423D-96B4-2BA65C8F7BAC}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/detour/releases/download/v0.1.3/detour.msi
+    InstallerSha256: 8f676d4547a1d541fedf1be00f66654c4333f3dd6d8f4b2edc15c7aad49d8763
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Detour/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Detour/locale.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.Detour
+PackageVersion: 0.1.3
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/detour/issues
+Author: Thomas Bray
+PackageName: Detour
+PackageUrl: https://github.com/Midtown-Technology-Group/detour
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/Midtown-Technology-Group/detour/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Track the work you did to get back to the work you meant to do.
+Description: |
+  Track the work you did to get back to the work you meant to do.
+Moniker: detour
+Tags:
+  - cli
+  - productivity
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for Detour.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/detour/releases/tag/v0.1.3
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Detour/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Detour/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.Detour
+PackageVersion: 0.1.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/GtdDashboard/0.1.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/GtdDashboard/0.1.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.GtdDashboard
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{B3D2F6FB-50FC-41BD-B0BB-F7AA0582F7F3}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/gtd-dashboard/releases/download/v0.1.0/gtd-dashboard.msi
+    InstallerSha256: 495a6c6440e2920763642593c32742c463216a042886bdabb009611b2c7924a2
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/GtdDashboard/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/GtdDashboard/locale.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.GtdDashboard
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/gtd-dashboard/issues
+Author: Thomas Bray
+PackageName: GTD Dashboard
+PackageUrl: https://github.com/Midtown-Technology-Group/gtd-dashboard
+License: AGPL-3.0
+LicenseUrl: https://github.com/Midtown-Technology-Group/gtd-dashboard/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: GTD Dashboard CLI for Logseq knowledge graphs
+Description: |
+  GTD Dashboard CLI for Logseq knowledge graphs
+Moniker: gtd-dashboard
+Tags:
+  - gtd
+  - logseq
+  - cli
+  - productivity
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for GTD Dashboard.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/gtd-dashboard/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/GtdDashboard/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/GtdDashboard/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.GtdDashboard
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Halocli/0.5.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Halocli/0.5.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.Halocli
+PackageVersion: 0.5.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{12FECE31-E90A-47A1-B8FC-9F20DD34CBBF}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/halocli/releases/download/v0.5.0/halocli.msi
+    InstallerSha256: f2500d4d97f63e1306a0c40312b67dc5544a4cf1279896c517d80f05ca2d69a9
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Halocli/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Halocli/locale.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.Halocli
+PackageVersion: 0.5.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/halocli/issues
+Author: Thomas Bray
+PackageName: Halocli
+PackageUrl: https://github.com/Midtown-Technology-Group/halocli
+License: GPL-3.0-only
+LicenseUrl: https://github.com/Midtown-Technology-Group/halocli/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Standalone HaloPSA CLI for safe operator and automation workflows
+Description: |
+  Standalone HaloPSA CLI for safe operator and automation workflows
+Moniker: halocli
+Tags:
+  - halo
+  - cli
+  - productivity
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for Halocli.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/halocli/releases/tag/v0.5.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Halocli/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Halocli/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.Halocli
+PackageVersion: 0.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/MeetingCostTracker/0.1.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/MeetingCostTracker/0.1.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.MeetingCostTracker
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{B514BE90-5C07-46C5-BDD6-AB15779ED38C}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/meeting-cost-tracker/releases/download/v0.1.0/mct.msi
+    InstallerSha256: c32c225d2399c9d2493eac31a7e7e5b18af9ea1e21b3e97a73199901d93f52c9
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/MeetingCostTracker/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/MeetingCostTracker/locale.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.MeetingCostTracker
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/meeting-cost-tracker/issues
+Author: Thomas Bray
+PackageName: Meeting Cost Tracker
+PackageUrl: https://github.com/Midtown-Technology-Group/meeting-cost-tracker
+License: AGPL-3.0
+LicenseUrl: https://github.com/Midtown-Technology-Group/meeting-cost-tracker/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Track the real cost of Microsoft Teams meetings by participant time
+Description: |
+  Track the real cost of Microsoft Teams meetings by participant time
+Moniker: mct
+Tags:
+  - teams
+  - time
+  - cli
+  - productivity
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for Meeting Cost Tracker.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/meeting-cost-tracker/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/MeetingCostTracker/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/MeetingCostTracker/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.MeetingCostTracker
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/QuickCapture/0.1.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/QuickCapture/0.1.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.QuickCapture
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{9BBD194F-013E-4A26-81BD-B4ED836F5937}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/quick-capture/releases/download/v0.1.0/quick-capture.msi
+    InstallerSha256: 4bba4f8ac12e55a5dd1813adb5df1c575bfb515ced1716a4aed44a71e4d6f483
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/QuickCapture/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/QuickCapture/locale.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.QuickCapture
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/quick-capture/issues
+Author: Thomas Bray
+PackageName: Quick Capture
+PackageUrl: https://github.com/Midtown-Technology-Group/quick-capture
+License: AGPL-3.0-or-later
+LicenseUrl: https://github.com/Midtown-Technology-Group/quick-capture/blob/main/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Fast, frictionless capture for Logseq daily notes
+Description: |
+  Fast, frictionless capture for Logseq daily notes
+Moniker: quick-capture
+Tags:
+  - logseq
+  - notes
+  - cli
+  - productivity
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for Quick Capture.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/quick-capture/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/QuickCapture/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/QuickCapture/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.QuickCapture
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/TimeTracker/0.1.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/TimeTracker/0.1.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.TimeTracker
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{FFF9CCD3-C065-4399-AA2A-268843AD22EF}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/time-tracker/releases/download/v0.1.0/time-tracker.msi
+    InstallerSha256: 02216dfc616f424253a34a1f379c51ee6c8464182ede20429f913716d8d8d194
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/TimeTracker/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/TimeTracker/locale.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.TimeTracker
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/time-tracker/issues
+Author: Thomas Bray
+PackageName: Time Tracker
+PackageUrl: https://github.com/Midtown-Technology-Group/time-tracker
+License: AGPL-3.0
+LicenseUrl: https://github.com/Midtown-Technology-Group/time-tracker/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Track time on tasks with zero friction. Integrates with GTD workflows.
+Description: |
+  Track time on tasks with zero friction. Integrates with GTD workflows.
+Moniker: time-tracker
+Tags:
+  - gtd
+  - time
+  - cli
+  - productivity
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for Time Tracker.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/time-tracker/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/TimeTracker/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/TimeTracker/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.TimeTracker
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/WeeklyReview/0.1.0.yaml
+++ b/manifests/m/MidtownTechnologyGroup/WeeklyReview/0.1.0.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.WeeklyReview
+PackageVersion: 0.1.0
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{9915178F-F778-4473-A439-E953C315E1C4}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/Midtown-Technology-Group/weekly-review/releases/download/v0.1.0/weekly-review.msi
+    InstallerSha256: 9868323ff3f489158a70a63207992654211a1500f36e805ed8653375ee2e3b1b
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/WeeklyReview/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/WeeklyReview/locale.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.WeeklyReview
+PackageVersion: 0.1.0
+PackageLocale: en-US
+Publisher: Midtown Technology Group LLC
+PublisherUrl: https://midtowntg.com
+PublisherSupportUrl: https://github.com/Midtown-Technology-Group/weekly-review/issues
+Author: Thomas Bray
+PackageName: Weekly Review
+PackageUrl: https://github.com/Midtown-Technology-Group/weekly-review
+License: AGPL-3.0
+LicenseUrl: https://github.com/Midtown-Technology-Group/weekly-review/blob/master/LICENSE
+Copyright: Copyright (c) 2026 Midtown Technology Group LLC
+ShortDescription: Automated GTD weekly review generator for Logseq knowledge graphs
+Description: |
+  Automated GTD weekly review generator for Logseq knowledge graphs
+Moniker: weekly-review
+Tags:
+  - gtd
+  - logseq
+  - cli
+  - productivity
+  - midtown
+ReleaseNotes: |
+  Initial MSI release for Weekly Review.
+ReleaseNotesUrl: https://github.com/Midtown-Technology-Group/weekly-review/releases/tag/v0.1.0
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/WeeklyReview/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/WeeklyReview/version.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.WeeklyReview
+PackageVersion: 0.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/packageManifests/m/MidtownTechnologyGroup/ContextSync/1.0.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/ContextSync/1.0.0.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.ContextSync",
+    "versions": [
+      {
+        "packageVersion": "1.0.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/context-sync/issues",
+          "author": "Thomas Bray",
+          "packageName": "Context Sync",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/context-sync",
+          "license": "MIT",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/context-sync/blob/main/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Sync Microsoft 365 work context to LogSeq knowledge graph",
+          "description": "Sync Microsoft 365 work context to LogSeq knowledge graph",
+          "moniker": "work-context-sync",
+          "tags": [
+            "logseq",
+            "microsoft-365",
+            "cli",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for Context Sync.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/context-sync/releases/tag/v1.0.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/context-sync/releases/download/v1.0.0/work-context-sync.msi",
+            "installerSha256": "fcf457fa69c3cbd09fb0152a268b1c9dd3c05e38f5dc492e39b019df1f3f350d",
+            "productCode": "{1AFC5B16-0EA6-4616-8D7D-95FB3070E808}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packageManifests/m/MidtownTechnologyGroup/Detour/0.1.3.json
+++ b/packageManifests/m/MidtownTechnologyGroup/Detour/0.1.3.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.Detour",
+    "versions": [
+      {
+        "packageVersion": "0.1.3",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/detour/issues",
+          "author": "Thomas Bray",
+          "packageName": "Detour",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/detour",
+          "license": "AGPL-3.0-only",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/detour/blob/main/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Track the work you did to get back to the work you meant to do.",
+          "description": "Track the work you did to get back to the work you meant to do.",
+          "moniker": "detour",
+          "tags": [
+            "cli",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for Detour.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/detour/releases/tag/v0.1.3"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/detour/releases/download/v0.1.3/detour.msi",
+            "installerSha256": "8f676d4547a1d541fedf1be00f66654c4333f3dd6d8f4b2edc15c7aad49d8763",
+            "productCode": "{303221BB-88BF-423D-96B4-2BA65C8F7BAC}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packageManifests/m/MidtownTechnologyGroup/GtdDashboard/0.1.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/GtdDashboard/0.1.0.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.GtdDashboard",
+    "versions": [
+      {
+        "packageVersion": "0.1.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/gtd-dashboard/issues",
+          "author": "Thomas Bray",
+          "packageName": "GTD Dashboard",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/gtd-dashboard",
+          "license": "AGPL-3.0",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/gtd-dashboard/blob/master/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "GTD Dashboard CLI for Logseq knowledge graphs",
+          "description": "GTD Dashboard CLI for Logseq knowledge graphs",
+          "moniker": "gtd-dashboard",
+          "tags": [
+            "gtd",
+            "logseq",
+            "cli",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for GTD Dashboard.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/gtd-dashboard/releases/tag/v0.1.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/gtd-dashboard/releases/download/v0.1.0/gtd-dashboard.msi",
+            "installerSha256": "495a6c6440e2920763642593c32742c463216a042886bdabb009611b2c7924a2",
+            "productCode": "{B3D2F6FB-50FC-41BD-B0BB-F7AA0582F7F3}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packageManifests/m/MidtownTechnologyGroup/Halocli/0.5.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/Halocli/0.5.0.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.Halocli",
+    "versions": [
+      {
+        "packageVersion": "0.5.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/halocli/issues",
+          "author": "Thomas Bray",
+          "packageName": "Halocli",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/halocli",
+          "license": "GPL-3.0-only",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/halocli/blob/main/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Standalone HaloPSA CLI for safe operator and automation workflows",
+          "description": "Standalone HaloPSA CLI for safe operator and automation workflows",
+          "moniker": "halocli",
+          "tags": [
+            "halo",
+            "cli",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for Halocli.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/halocli/releases/tag/v0.5.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/halocli/releases/download/v0.5.0/halocli.msi",
+            "installerSha256": "f2500d4d97f63e1306a0c40312b67dc5544a4cf1279896c517d80f05ca2d69a9",
+            "productCode": "{12FECE31-E90A-47A1-B8FC-9F20DD34CBBF}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packageManifests/m/MidtownTechnologyGroup/MeetingCostTracker/0.1.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/MeetingCostTracker/0.1.0.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.MeetingCostTracker",
+    "versions": [
+      {
+        "packageVersion": "0.1.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/meeting-cost-tracker/issues",
+          "author": "Thomas Bray",
+          "packageName": "Meeting Cost Tracker",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/meeting-cost-tracker",
+          "license": "AGPL-3.0",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/meeting-cost-tracker/blob/master/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Track the real cost of Microsoft Teams meetings by participant time",
+          "description": "Track the real cost of Microsoft Teams meetings by participant time",
+          "moniker": "mct",
+          "tags": [
+            "teams",
+            "time",
+            "cli",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for Meeting Cost Tracker.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/meeting-cost-tracker/releases/tag/v0.1.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/meeting-cost-tracker/releases/download/v0.1.0/mct.msi",
+            "installerSha256": "c32c225d2399c9d2493eac31a7e7e5b18af9ea1e21b3e97a73199901d93f52c9",
+            "productCode": "{B514BE90-5C07-46C5-BDD6-AB15779ED38C}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packageManifests/m/MidtownTechnologyGroup/QuickCapture/0.1.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/QuickCapture/0.1.0.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.QuickCapture",
+    "versions": [
+      {
+        "packageVersion": "0.1.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/quick-capture/issues",
+          "author": "Thomas Bray",
+          "packageName": "Quick Capture",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/quick-capture",
+          "license": "AGPL-3.0-or-later",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/quick-capture/blob/main/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Fast, frictionless capture for Logseq daily notes",
+          "description": "Fast, frictionless capture for Logseq daily notes",
+          "moniker": "quick-capture",
+          "tags": [
+            "logseq",
+            "notes",
+            "cli",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for Quick Capture.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/quick-capture/releases/tag/v0.1.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/quick-capture/releases/download/v0.1.0/quick-capture.msi",
+            "installerSha256": "4bba4f8ac12e55a5dd1813adb5df1c575bfb515ced1716a4aed44a71e4d6f483",
+            "productCode": "{9BBD194F-013E-4A26-81BD-B4ED836F5937}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packageManifests/m/MidtownTechnologyGroup/TimeTracker/0.1.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/TimeTracker/0.1.0.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.TimeTracker",
+    "versions": [
+      {
+        "packageVersion": "0.1.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/time-tracker/issues",
+          "author": "Thomas Bray",
+          "packageName": "Time Tracker",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/time-tracker",
+          "license": "AGPL-3.0",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/time-tracker/blob/master/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Track time on tasks with zero friction. Integrates with GTD workflows.",
+          "description": "Track time on tasks with zero friction. Integrates with GTD workflows.",
+          "moniker": "time-tracker",
+          "tags": [
+            "gtd",
+            "time",
+            "cli",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for Time Tracker.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/time-tracker/releases/tag/v0.1.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/time-tracker/releases/download/v0.1.0/time-tracker.msi",
+            "installerSha256": "02216dfc616f424253a34a1f379c51ee6c8464182ede20429f913716d8d8d194",
+            "productCode": "{FFF9CCD3-C065-4399-AA2A-268843AD22EF}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packageManifests/m/MidtownTechnologyGroup/WeeklyReview/0.1.0.json
+++ b/packageManifests/m/MidtownTechnologyGroup/WeeklyReview/0.1.0.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.WeeklyReview",
+    "versions": [
+      {
+        "packageVersion": "0.1.0",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/Midtown-Technology-Group/weekly-review/issues",
+          "author": "Thomas Bray",
+          "packageName": "Weekly Review",
+          "packageUrl": "https://github.com/Midtown-Technology-Group/weekly-review",
+          "license": "AGPL-3.0",
+          "licenseUrl": "https://github.com/Midtown-Technology-Group/weekly-review/blob/master/LICENSE",
+          "copyright": "Copyright (c) 2026 Midtown Technology Group LLC",
+          "shortDescription": "Automated GTD weekly review generator for Logseq knowledge graphs",
+          "description": "Automated GTD weekly review generator for Logseq knowledge graphs",
+          "moniker": "weekly-review",
+          "tags": [
+            "gtd",
+            "logseq",
+            "cli",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Initial MSI release for Weekly Review.",
+          "releaseNotesUrl": "https://github.com/Midtown-Technology-Group/weekly-review/releases/tag/v0.1.0"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/Midtown-Technology-Group/weekly-review/releases/download/v0.1.0/weekly-review.msi",
+            "installerSha256": "9868323ff3f489158a70a63207992654211a1500f36e805ed8653375ee2e3b1b",
+            "productCode": "{9915178F-F778-4473-A439-E953C315E1C4}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add WinGet manifests for eight Python CLI MSI releases
- include released MSI URLs, SHA256 hashes, and ProductCodes

## Verification
- python -m json.tool over index.json and packageManifests JSON
- git diff --cached --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->