### PR TITLE
Use PAT secret for feed update pull requests

### DIFF
--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -84,8 +84,12 @@ jobs:
       - name: Open package update pull request
         if: steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.MTG_WINGET_PR_TOKEN }}
         run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "MTG_WINGET_PR_TOKEN is required because GitHub Actions cannot create pull requests with GITHUB_TOKEN in this repository."
+            exit 1
+          fi
           gh pr create \
             --base main \
             --head "${{ steps.commit.outputs.branch }}" \


### PR DESCRIPTION
## Summary
- use MTG_WINGET_PR_TOKEN when update-package automation opens feed update PRs
- fail with an explicit message if the PAT-backed secret is missing

## Verification
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->