### PR TITLE
Fix WinGet REST source URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Private Winget REST source for Midtown Technology Group internal tools.
 ## Client usage
 
 ```powershell
-winget source add -n mtg-tools -a https://winget.midtowntg.com -t Microsoft.Rest
+winget source add -n mtg-tools -a https://winget.midtowntg.com/api -t Microsoft.Rest
 winget source update
 winget search --source mtg-tools
 ```

--- a/source.json
+++ b/source.json
@@ -4,7 +4,7 @@
     "sourceIdentifier": "mtg-tools",
     "sourceName": "Midtown Technology Group Tools",
     "sourceType": "Microsoft.Rest",
-    "sourceUrl": "https://winget.midtowntg.com",
+    "sourceUrl": "https://winget.midtowntg.com/api",
     "sourceAgreements": {
       "agreementUrl": "https://midtowntg.com/terms",
       "agreement": [


### PR DESCRIPTION
Updates the feed source URL and docs to use the Azure Functions API root (https://winget.midtowntg.com/api) instead of the Static Web Apps site root.\n\nWhy:\n- The REST endpoints WinGet uses live under /api.\n- Existing configured source on this machine works as /api.\n- A first-run source configured at the site root can reach some static routes but can fail when retrieving package manifests through the REST path.\n\nVerification:\n- python -m json.tool source.json\n- python -m json.tool api/data/source.json\n- pwsh -NoProfile -File scripts/prepare_site.ps1\n- Invoke-WebRequest https://winget.midtowntg.com/api/information\n- Invoke-WebRequest https://winget.midtowntg.com/api/manifestSearch\n- Invoke-WebRequest https://winget.midtowntg.com/api/packageManifests/MidtownTechnologyGroup.Voquill

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->