### PR TITLE
Update Voquill feed package to 1.3.14

### DIFF
--- a/index.json
+++ b/index.json
@@ -215,7 +215,7 @@
       "Publisher": "Midtown Technology Group LLC",
       "Versions": [
         {
-          "PackageVersion": "1.3.13",
+          "PackageVersion": "1.3.14",
           "DefaultLocale": {
             "PackageLocale": "en-US",
             "Publisher": "Midtown Technology Group LLC",

--- a/manifests/m/MidtownTechnologyGroup/Voquill/1.3.14.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Voquill/1.3.14.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.Voquill
+PackageVersion: 1.3.14
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{C65AD20B-AE2D-4F05-ADA7-46D5593F4072}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/MTG-Thomas/voquill/releases/download/mtg-v1.3.14/Voquill_1.3.14_x64_en-US.msi
+    InstallerSha256: c0a72ee83d9269d1b26c93eb11cf9b883f701b8384d84d5a613dcc3963a94e51
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Voquill/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Voquill/locale.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: MidtownTechnologyGroup.Voquill
-PackageVersion: 1.3.13
+PackageVersion: 1.3.14
 PackageLocale: en-US
 Publisher: Midtown Technology Group LLC
 PublisherUrl: https://midtowntg.com
@@ -25,7 +25,7 @@ Tags:
   - productivity
   - midtown
 ReleaseNotes: |
-  Fork-local MTG release for team testing.
-ReleaseNotesUrl: https://github.com/MTG-Thomas/voquill/releases/tag/mtg-v1.3.13
+  Fixes packaged-app permissions for OpenVINO model warmup and overlay positioning, with CI coverage for missing Tauri command ACL entries.
+ReleaseNotesUrl: https://github.com/MTG-Thomas/voquill/releases/tag/mtg-v1.3.14
 ManifestType: defaultLocale
 ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Voquill/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Voquill/version.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: MidtownTechnologyGroup.Voquill
-PackageVersion: 1.3.13
+PackageVersion: 1.3.14
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.5.0

--- a/packageManifests/m/MidtownTechnologyGroup/Voquill/1.3.14.json
+++ b/packageManifests/m/MidtownTechnologyGroup/Voquill/1.3.14.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.Voquill",
+    "versions": [
+      {
+        "packageVersion": "1.3.14",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/MTG-Thomas/voquill/issues",
+          "author": "Jack Brumley, MTG-Thomas fork maintainers",
+          "packageName": "Voquill",
+          "packageUrl": "https://github.com/MTG-Thomas/voquill",
+          "license": "AGPL-3.0-only",
+          "licenseUrl": "https://github.com/MTG-Thomas/voquill/blob/main/LICENSE",
+          "copyright": "Copyright (c) Voquill contributors",
+          "shortDescription": "Push-to-talk dictation app with local transcription support",
+          "description": "Cross-platform push-to-talk dictation app with Whisper-powered speech recognition and MTG fork enhancements for local Windows dictation workflows.",
+          "moniker": "voquill",
+          "tags": [
+            "dictation",
+            "speech-to-text",
+            "whisper",
+            "openvino",
+            "npu",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Fixes packaged-app permissions for OpenVINO model warmup and overlay positioning, with CI coverage for missing Tauri command ACL entries.",
+          "releaseNotesUrl": "https://github.com/MTG-Thomas/voquill/releases/tag/mtg-v1.3.14"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/MTG-Thomas/voquill/releases/download/mtg-v1.3.14/Voquill_1.3.14_x64_en-US.msi",
+            "installerSha256": "c0a72ee83d9269d1b26c93eb11cf9b883f701b8384d84d5a613dcc3963a94e51",
+            "productCode": "{C65AD20B-AE2D-4F05-ADA7-46D5593F4072}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/voquill.json
+++ b/packages/voquill.json
@@ -21,10 +21,10 @@
     "productivity",
     "midtown"
   ],
-  "releaseNotes": "Fork-local MTG release for team testing.",
+  "releaseNotes": "Fixes packaged-app permissions for OpenVINO model warmup and overlay positioning, with CI coverage for missing Tauri command ACL entries.",
   "repo": "MTG-Thomas/voquill",
   "releaseTagTemplate": "mtg-v{version}",
-  "assetName": "Voquill_1.3.13_x64_en-US.msi",
+  "assetName": "Voquill_1.3.14_x64_en-US.msi",
   "architecture": "x64",
   "installerType": "msi",
   "scope": "machine",


### PR DESCRIPTION
Updates the private WinGet feed to Voquill 1.3.14.\n\nVerification:\n- python -m json.tool index.json\n- python -m json.tool packageManifests/m/MidtownTechnologyGroup/Voquill/1.3.14.json\n- python -m json.tool packages/voquill.json\n- pwsh -NoProfile -File scripts/prepare_site.ps1\n- winget validate on a temporary single-version manifest folder

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed packaged-app permission restrictions that were interfering with OpenVINO model warmup operations
  * Corrected overlay positioning alignment issues
  * Expanded continuous integration test coverage for Tauri command access control configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Midtown-Technology-Group/mtg-winget/pull/12)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->