### PR TITLE
Update Voquill package to 1.3.21

### DIFF
--- a/index.json
+++ b/index.json
@@ -215,7 +215,7 @@
       "Publisher": "Midtown Technology Group LLC",
       "Versions": [
         {
-          "PackageVersion": "1.3.14",
+          "PackageVersion": "1.3.21",
           "DefaultLocale": {
             "PackageLocale": "en-US",
             "Publisher": "Midtown Technology Group LLC",

--- a/manifests/m/MidtownTechnologyGroup/Voquill/1.3.21.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Voquill/1.3.21.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+
+PackageIdentifier: MidtownTechnologyGroup.Voquill
+PackageVersion: 1.3.21
+MinimumOSVersion: 10.0.0.0
+InstallerType: msi
+Scope: machine
+UpgradeBehavior: install
+ProductCode: '{6DA0A05E-4595-4328-BF8B-75141A865F39}'
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/MTG-Thomas/voquill/releases/download/mtg-v1.3.21/Voquill_1.3.21_x64_en-US.msi
+    InstallerSha256: 50F74DD0B3AF339D3A31DE5B838B4F9AF2F7782E216CA54D1362FB0D639CBBDD
+    InstallerSwitches:
+      Silent: /qn
+      SilentWithProgress: /qb
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Voquill/locale.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Voquill/locale.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
 
 PackageIdentifier: MidtownTechnologyGroup.Voquill
-PackageVersion: 1.3.14
+PackageVersion: 1.3.21
 PackageLocale: en-US
 Publisher: Midtown Technology Group LLC
 PublisherUrl: https://midtowntg.com
@@ -25,7 +25,7 @@ Tags:
   - productivity
   - midtown
 ReleaseNotes: |
-  Fixes packaged-app permissions for OpenVINO model warmup and overlay positioning, with CI coverage for missing Tauri command ACL entries.
-ReleaseNotesUrl: https://github.com/MTG-Thomas/voquill/releases/tag/mtg-v1.3.14
+  Adds Windows 11 native styling defaults, CI release fixes, sccache build acceleration, and macOS release artifacts.
+ReleaseNotesUrl: https://github.com/MTG-Thomas/voquill/releases/tag/mtg-v1.3.21
 ManifestType: defaultLocale
 ManifestVersion: 1.5.0

--- a/manifests/m/MidtownTechnologyGroup/Voquill/version.yaml
+++ b/manifests/m/MidtownTechnologyGroup/Voquill/version.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
 
 PackageIdentifier: MidtownTechnologyGroup.Voquill
-PackageVersion: 1.3.14
+PackageVersion: 1.3.21
 DefaultLocale: en-US
 ManifestType: version
 ManifestVersion: 1.5.0

--- a/packageManifests/m/MidtownTechnologyGroup/Voquill/1.3.21.json
+++ b/packageManifests/m/MidtownTechnologyGroup/Voquill/1.3.21.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://aka.ms/winget-rest-source.schema.json",
+  "data": {
+    "packageIdentifier": "MidtownTechnologyGroup.Voquill",
+    "versions": [
+      {
+        "packageVersion": "1.3.21",
+        "defaultLocale": {
+          "packageLocale": "en-US",
+          "publisher": "Midtown Technology Group LLC",
+          "publisherUrl": "https://midtowntg.com",
+          "publisherSupportUrl": "https://github.com/MTG-Thomas/voquill/issues",
+          "author": "Jack Brumley, MTG-Thomas fork maintainers",
+          "packageName": "Voquill",
+          "packageUrl": "https://github.com/MTG-Thomas/voquill",
+          "license": "AGPL-3.0-only",
+          "licenseUrl": "https://github.com/MTG-Thomas/voquill/blob/main/LICENSE",
+          "copyright": "Copyright (c) Voquill contributors",
+          "shortDescription": "Push-to-talk dictation app with local transcription support",
+          "description": "Cross-platform push-to-talk dictation app with Whisper-powered speech recognition and MTG fork enhancements for local Windows dictation workflows.",
+          "moniker": "voquill",
+          "tags": [
+            "dictation",
+            "speech-to-text",
+            "whisper",
+            "openvino",
+            "npu",
+            "productivity",
+            "midtown"
+          ],
+          "releaseNotes": "Adds Windows 11 native styling defaults, CI release fixes, sccache build acceleration, and macOS release artifacts.",
+          "releaseNotesUrl": "https://github.com/MTG-Thomas/voquill/releases/tag/mtg-v1.3.21"
+        },
+        "installers": [
+          {
+            "architecture": "x64",
+            "installerType": "msi",
+            "scope": "machine",
+            "installerUrl": "https://github.com/MTG-Thomas/voquill/releases/download/mtg-v1.3.21/Voquill_1.3.21_x64_en-US.msi",
+            "installerSha256": "50F74DD0B3AF339D3A31DE5B838B4F9AF2F7782E216CA54D1362FB0D639CBBDD",
+            "productCode": "{6DA0A05E-4595-4328-BF8B-75141A865F39}",
+            "upgradeBehavior": "install",
+            "installerSwitches": {
+              "silent": "/qn",
+              "silentWithProgress": "/qb"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/voquill.json
+++ b/packages/voquill.json
@@ -21,10 +21,10 @@
     "productivity",
     "midtown"
   ],
-  "releaseNotes": "Fixes packaged-app permissions for OpenVINO model warmup and overlay positioning, with CI coverage for missing Tauri command ACL entries.",
+  "releaseNotes": "Adds Windows 11 native styling defaults, CI release fixes, sccache build acceleration, and macOS release artifacts.",
   "repo": "MTG-Thomas/voquill",
   "releaseTagTemplate": "mtg-v{version}",
-  "assetName": "Voquill_1.3.14_x64_en-US.msi",
+  "assetName": "Voquill_1.3.21_x64_en-US.msi",
   "architecture": "x64",
   "installerType": "msi",
   "scope": "machine",


### PR DESCRIPTION
## Summary
- update the live mtg-tools Voquill package index to 1.3.21
- add the 1.3.21 WinGet installer and REST package manifest entries
- point the package at the published MTG-Thomas/voquill MSI and verified SHA256

## Verification
- winget validate/show using a temp manifest set containing version.yaml, locale.yaml, and 1.3.21.yaml
- JSON.parse for index.json and packageManifests/m/MidtownTechnologyGroup/Voquill/1.3.21.json

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->