### PR TITLE
Document explicit mtg-tools WinGet source

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,21 @@ Private Winget REST source for Midtown Technology Group internal tools.
 ## Client usage
 
 ```powershell
-winget source add -n mtg-tools -a https://winget.midtowntg.com/api -t Microsoft.Rest
+winget source add -n mtg-tools -a https://winget.midtowntg.com/api -t Microsoft.Rest --explicit
 winget source update
 winget search --source mtg-tools
 ```
 
 WinGet defaults to the pre-indexed MSIX source type when `-t Microsoft.Rest`
 is omitted, which makes it look for `source2.msix` or `source.msix`.
+
+Keep `mtg-tools` registered as an explicit source. If it is implicit, ordinary
+commands such as `winget install --id jj-vcs.jj` query this private REST source
+alongside the public `winget` source; any stale source state or unsupported REST
+endpoint can then fail unrelated public package installs with errors like
+`0x8a150044 : The rest API endpoint is not found.` Use `--source mtg-tools`
+for MTG packages and `--source winget` for public packages when a command must
+be unambiguous.
 
 ## Operations
 


### PR DESCRIPTION
## Summary
- add --explicit to the mtg-tools source registration example
- document why MTG packages should use --source mtg-tools and public packages should use --source winget when commands need to be unambiguous

## Verification
- git diff --check -- README.md

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->