### PR TITLE
Fix winget upgrade --all for mtg-tools source

### DIFF
--- a/api/lib/feed.js
+++ b/api/lib/feed.js
@@ -184,6 +184,7 @@ function packageFieldValues(pkg, packageMatchField) {
         (version.installers || []).map((installer) => installer.productCode)
       );
     case "normalizednameandpublisher":
+    case "normalizedpackagenameandpublisher":
       return [
         `${normalizeSearchValue(pkg.PackageName)} ${normalizeSearchValue(pkg.Publisher)}`,
         ...locales.map(
@@ -211,6 +212,7 @@ function isSupportedPackageMatchField(packageMatchField) {
     "moniker",
     "name",
     "normalizednameandpublisher",
+    "normalizedpackagenameandpublisher",
     "packagefamilyname",
     "packageidentifier",
     "packagename",

--- a/api/test/feed.test.js
+++ b/api/test/feed.test.js
@@ -73,6 +73,30 @@ assertSearch(
 );
 
 assertSearch(
+  "normalized package name and publisher filter (winget client field name)",
+  {
+    Filters: [
+      {
+        PackageMatchField: "NormalizedPackageNameAndPublisher",
+        RequestMatch: { KeyWord: "voquill+midtown technology group llc", MatchType: "Exact" }
+      }
+    ]
+  },
+  ["MidtownTechnologyGroup.Voquill"]
+);
+
+const unsupportedNormalizedAlias = feed.manifestSearch({
+  Filters: [
+    {
+      PackageMatchField: "NormalizedPackageNameAndPublisher",
+      RequestMatch: { KeyWord: "not-a-real-package", MatchType: "Exact" }
+    }
+  ]
+});
+assert.deepStrictEqual(packageIdentifiers(unsupportedNormalizedAlias), []);
+assert.deepStrictEqual(unsupportedNormalizedAlias.UnsupportedPackageMatchFields, []);
+
+assertSearch(
   "publisher inclusion remains broad",
   {
     Inclusions: [

--- a/information.json
+++ b/information.json
@@ -2,7 +2,8 @@
   "Data": {
     "SourceIdentifier": "mtg-tools",
     "ServerSupportedVersions": [
-      "1.4.0"
+      "1.4.0",
+      "1.7.0"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Recognize WinGet''s `NormalizedPackageNameAndPublisher` match field (the name the client actually sends over REST).
- Stop returning that field in `UnsupportedPackageMatchFields` on zero-match correlation searches, which caused `0x8a150043` during `winget upgrade --all`.
- Advertise REST API `1.7.0` in `information.json`.

## Test plan
- [x] `npm test` in `api/`
- [ ] Merge and confirm `Deploy Winget Feed` workflow succeeds
- [ ] `winget source update mtg-tools` then `winget upgrade --all` on a client machine

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782654606&installation_id=128965599&pr_number=16&repository=Midtown-Technology-Group%2Fmtg-winget&return_to=https%3A%2F%2Fgithub.com%2FMidtown-Technology-Group%2Fmtg-winget%2Fpull%2F16&signature=d21aef8b1c83d2e270eb19b2768be1aa90d60d52a04b1d48f1ca83b8ea569fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Search-field alias and version metadata only; behavior mirrors an existing match type with added regression tests.
> 
> **Overview**
> Treats WinGet’s **`NormalizedPackageNameAndPublisher`** filter as supported (same normalized name+publisher matching as **`NormalizedNameAndPublisher`**), so correlation searches from the client no longer flag that field as unsupported when there are zero matches—addressing **`winget upgrade --all`** failures (**`0x8a150043`**).
> 
> Adds feed tests for the client field name and asserts an empty result does **not** populate **`UnsupportedPackageMatchFields`** for that alias.
> 
> Updates static **`information.json`** to advertise REST API **`1.7.0`** alongside **`1.4.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00d935ebc8fc50f1cd9ae947d360e9ac9e8c7837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for normalized package name and publisher search filtering.

* **Chores**
  * Added compatibility for server version 1.7.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Midtown-Technology-Group/mtg-winget/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->