### PR TITLE
Fix SWA deploy blocked by auth SKU requirement

### DIFF
--- a/scripts/prepare_site.ps1
+++ b/scripts/prepare_site.ps1
@@ -11,6 +11,16 @@ Copy-Item (Join-Path $PSScriptRoot "..\\index.html") $site
 Copy-Item (Join-Path $PSScriptRoot "..\\source.json") $site
 Copy-Item (Join-Path $PSScriptRoot "..\\information.json") $site
 Copy-Item (Join-Path $PSScriptRoot "..\\staticwebapp.config.json") $site
+
+# The auth block in staticwebapp.config.json requires SWA Standard SKU at deploy time.
+# Keep it in-repo for portal documentation, but omit it from the uploaded site payload.
+$siteConfigPath = Join-Path $site "staticwebapp.config.json"
+$siteConfig = Get-Content $siteConfigPath -Raw | ConvertFrom-Json
+if ($null -ne $siteConfig.auth) {
+    $siteConfig.PSObject.Properties.Remove("auth")
+    $siteConfig | ConvertTo-Json -Depth 20 | Set-Content -Path $siteConfigPath -Encoding utf8
+}
+
 Copy-Item -Recurse (Join-Path $PSScriptRoot "..\\packageManifests") $site
 Copy-Item -Recurse (Join-Path $PSScriptRoot "..\\manifests") $site
 


### PR DESCRIPTION
## Summary
- Strip the `auth` block from `staticwebapp.config.json` in the `_site` payload during `prepare_site.ps1`.
- Unblocks `Deploy Winget Feed` on the current Free SKU (Azure rejects in-file auth unless Standard).

## Test plan
- [x] `prepare_site.ps1` locally; deployed `_site/staticwebapp.config.json` has no `auth` key
- [ ] Merge and confirm `Deploy Winget Feed` succeeds (includes PR #16 API fix)

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Midtown-Technology-Group/codesmith/mtg-winget/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782654869&installation_id=128965599&pr_number=17&repository=Midtown-Technology-Group%2Fmtg-winget&return_to=https%3A%2F%2Fgithub.com%2FMidtown-Technology-Group%2Fmtg-winget%2Fpull%2F17&signature=602d8f2877cb1efd5af7d62924ea130527be7e7d7c3041625d3af9b7b46542d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time JSON transform in prepare_site.ps1 only; auth remains in source config but is not deployed until Standard SKU.
> 
> **Overview**
> **Deploy Winget Feed** was failing on Azure Static Web Apps **Free** SKU because the uploaded `staticwebapp.config.json` included an in-file **`auth`** block (AAD), which Azure only allows on **Standard**.
> 
> `prepare_site.ps1` now removes **`auth`** from the copied config under **`_site`** after the file is staged, while the repo root **`staticwebapp.config.json`** stays unchanged for portal/docs. No runtime app logic changes—only the site prep payload differs at deploy time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a43a759d568912e0fb7e3e5e812ff36644805849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->